### PR TITLE
Graph is no longer encoded in the filesystem

### DIFF
--- a/Posts/CatA.toml
+++ b/Posts/CatA.toml
@@ -1,0 +1,2 @@
+type = "Category"
+name="CatA"

--- a/Posts/Mecha.toml
+++ b/Posts/Mecha.toml
@@ -1,0 +1,5 @@
+type="Category"
+name="Mecha"
+parents = ["SciFi"]
+dirname = "Category"
+aliases = ["misc studio", "shoji kawamori", "cyber", "mecha"]

--- a/Posts/catB.toml
+++ b/Posts/catB.toml
@@ -1,4 +1,3 @@
-type="Category"
-name="Mecha"
-parents = ["SciFi"]
-aliases = ["misc studio", "shoji kawamori", "cyber", "mecha"]
+type = "Category"
+name="CatB"
+parents = ["CatA"]

--- a/Posts/omega.toml
+++ b/Posts/omega.toml
@@ -5,7 +5,7 @@ year = "1993"
 description = "Omega Boost"
 image = "https://gamefaqs.akamaized.net/box/8/6/6/5866_front.jpg"
 dl_url = "url.org/#64zx79sYfq2TD82vTexI19DKua4Ns8YXMHBYWkrsCMpUZRaj1QLAUjKxIApEE1cQGt8wviSh8pH58N623HviJiFq7T4oFlOZCMov"
-parents = ["SciFi", "Mecha"]
+parents = ["SciFi", "Category/Mecha", "CatB"]
 ---
 Lorem ipsum dolor sit amet, magna iusto senserit vel in, ignota eirmod officiis cu quo, posidonium necessitatibus no eum. Cu mea diceret mediocrem dissentias, sed partem recusabo invenire ut. Ex adipisci tacimates pri. Vide nemore molestie ad quo. Mea quidam regione antiopam te. Eius iracundia eam ad, putent nominavi ex eos.
 

--- a/Posts/post2.toml
+++ b/Posts/post2.toml
@@ -1,3 +1,3 @@
 type = "Post"
 name="post2"
-parents=["SciFi"]
+parents=["CatB"]

--- a/Posts/star_control_1.toml
+++ b/Posts/star_control_1.toml
@@ -1,0 +1,10 @@
+type = "Post"
+name = 'Star Control: Famous Battles of the Ur-Quan Conflict, Volume IV'
+aliases = ["Star Control"]
+image = "http://4.bp.blogspot.com/-uJiRZMgyuQ0/UQVwZc-XwYI/AAAAAAAAArI/N7rhTIeb2-Y/s1600/36313-star-control-amiga-screenshot-the-syreen-penetrators-1.gif"
+year = "1990"
+parents = ["SciFi"]
+---
+**Star Control: Famous Battles of the Ur-Quan Conflict Volume IV** was developed by Fred Ford and Paul Reiche III. It was released for the PC in 1990 and (in a somewhat cut-down form, and called simply Star Control) for the Commodore 64 in 1991 by Accolade. 
+
+A port for the Sega Genesis was released by Ballistic in that same year. The DOS version is available from Good Old Games.

--- a/Posts/star_control_2.toml
+++ b/Posts/star_control_2.toml
@@ -3,7 +3,7 @@ name = 'Star Control II - The Urquan Masters'
 aliases = ["Star Control II", "Star Control 2"]
 image = "https://draginol.stardock.net/images2018/The-art-of-Star-Control_C786/image.png"
 year = "1992"
-parents = ["SciFi"]
+parents = ["SciFi", "Star Control"]
 ---
 **Star Control II: The Ur-Quan Masters** is a science fiction video game, a sequel to Star Control. It was developed by Toys for Bob and originally published by Accolade in 1992 for MS-DOS. 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # redsystem
-Static blog generator with cyclical digraph structure
+Static blog generator with a digraph structure (ie cycles allowed)
 
-Any blog post/category can be a child of any post/category. Multiple paths can lead to the same post, so to statically record the path taken in the URL, symlinks are generated to keep the path. To handle a cycle, we retreat back up the path to previous instance of the post. 
+Any blog post/category can be a child of any post/category. Multiple paths can lead to the same post. The path taken is **not** recorded anywhere. JS is currently not used, and at no point should ever be required.
 
-Since the individual post doesn't actually know where they are in the path (since we're just following symlinks to the same single post), JS is required to support cycle-detection, and update the url. If JS is turned off, the link pointing to a cycle will instead 404. [It might be possible to do this statically.](https://github.com/setr/redsystem/issues/5)
 ```
 test% redsystem -h
 redsystem 0.1.0
@@ -42,17 +41,22 @@ The dividing line `---` is required if body text exists (otherwise redsystem wil
 
 Body text is parsed as standard markdown.
 
-
+Currently Categories can have body text, but its html template doesn't do anything with it.
 ```
 Metadata:
     [Required] type: "Post"
         Determines html template used, and possible metadata fields.
     [Required] name: String
         Canonical name of the document. Must be unique across all posts.
+    [Optional] dirname: String
+        The directory from root which will contain this. Acts as a namespace, and appears in the URL when visiting the page. ie "Artists" or "Artists/Tokyo". 
+        This is the canonical root directory of a node.
+    [Optional] aliases: [String]
+        Alternative names that this post can be referenced by. Must be unique across all posts in the `dirname` namespace.
     [Optional] parents: [String]
         List of parent nodes, referenced by name/alias. Duplicate references to the same parent will be ignored.
-    [Optional] aliases: [String]
-        Alternative names that this post can be referenced by. Must be unique across all posts.
+        If no parents are listed, or the parent "INDEX" exists, it will be attached to the implicit index node (which produces index.html).
+        Parents must be listed with the full path. ie if `Star Control` has alias `sc` and has dirname `Category`, then it be referenced as a parent with "Category/sc" or "Category/Star Control"
     [Optional] description: String
         Short one-line description of the post
     [Optional] image: String
@@ -66,31 +70,34 @@ or
         Determines html template used, and possible metadata fields.
     [Required] name: String
         Canonical name of the document. Must be unique across all posts.
+    [Optional] dirname: String
+        The directory from root which will contain this. Acts as a namespace, and appears in the URL when visiting the page. ie "Artists" or "Artists/Tokyo". 
+        This is the canonical root directory of a node.
+    [Optional] aliases: [String]
+        Alternative names that this post can be referenced by. Must be unique across all posts in the `dirname` namespace.
     [Optional] parents: [String]
         List of parent nodes, referenced by name/alias. Duplicate references to the same parent will be ignored.
-    [Optional] aliases: [String]
-        Alternative names that this post can be referenced by. Must be unique across all posts.
+        If no parents are listed, or the parent "INDEX" exists, it will be attached to the implicit index node (which produces index.html).
+        Parents must be listed with the full path. ie if `Star Control` has alias `sc` and has dirname `Category`, then it be referenced as a parent with "Category/sc" or "Category/Star Control"
 ```
 Note that the template used, and the required information for it, is determined by the `type`. Currently `type` can be either "Post" or "Category", where Post denotes something (ie a game), while Category denotes a group of things. 
 
-Note that they can reference each other (using the parents field) arbitrarily; that is, a post can be the parent of many categories, and a category can be the parent of many posts, or category-\>category, or whatever combination you wish.
+Note that they can reference each other (using the parents field) arbitrarily; that is, a post can be the parent of many categories, and a category can be the parent of many posts, or category-\>category, or whatever combination you wish. The only special node is the index (root) node.
 
-## Example Usage
+## Examples
 
 ### Example post
 ```
-type="Post"
-name = "Omega Boost"
-aliases=["Omega", "omega"]
-year = "1993"
-description = "Omega Boost"
-image = "https://gamefaqs.akamaized.net/box/8/6/6/5866_front.jpg"
-dl_url = "url.org/#64zx79sYfq2TD82vTexI19DKua4Ns8YXMHBYWkrsCMpUZRaj1QLAUjKxIApEE1cQGt8wviSh8pH58N623HviJiFq7T4oFlOZCMov"
-parents = ["misc studio", "shoji kawamori", "cyber", "mecha"]
+type = "Post"
+name = 'Star Control: Famous Battles of the Ur-Quan Conflict, Volume IV'
+aliases = ["Star Control"]
+image = "http://4.bp.blogspot.com/-uJiRZMgyuQ0/UQVwZc-XwYI/AAAAAAAAArI/N7rhTIeb2-Y/s1600/36313-star-control-amiga-screenshot-the-syreen-penetrators-1.gif"
+year = "1990"
+parents = ["SciFi"]
 ---
-Lorem ipsum dolor sit amet, magna iusto senserit vel in, ignota eirmod officiis cu quo, posidonium necessitatibus no eum. Cu mea diceret mediocrem dissentias, sed partem recusabo invenire ut. Ex adipisci tacimates pri. Vide nemore molestie ad quo. Mea quidam regione antiopam te. Eius iracundia eam ad, putent nominavi ex eos.
+**Star Control: Famous Battles of the Ur-Quan Conflict Volume IV** was developed by Fred Ford and Paul Reiche III. It was released for the PC in 1990 and (in a somewhat cut-down form, and called simply Star Control) for the Commodore 64 in 1991 by Accolade. 
 
-Lorem ipsum dolor sit amet, magna iusto senserit vel in, ignota eirmod officiis cu quo, posidonium necessitatibus no eum. Cu mea diceret mediocrem dissentias, sed partem recusabo invenire ut. Ex adipisci tacimates pri. Vide nemore molestie ad quo. Mea quidam regione antiopam te. Eius iracundia eam ad, putent nominavi ex eos.
+A port for the Sega Genesis was released by Ballistic in that same year. The DOS version is available from Good Old Games.
 ```
 ### Another Example post
 ```
@@ -99,7 +106,7 @@ name = 'Star Control II - The Urquan Masters'
 aliases = ["Star Control II", "Star Control 2"]
 image = "https://draginol.stardock.net/images2018/The-art-of-Star-Control_C786/image.png"
 year = "1992"
-parents = ["SciFi"]
+parents = ["SciFi", "Star Control"]
 ---
 **Star Control II: The Ur-Quan Masters** is a science fiction video game, a sequel to Star Control. It was developed by Toys for Bob and originally published by Accolade in 1992 for MS-DOS. 
 

--- a/templates/jinja2/category.jinja2
+++ b/templates/jinja2/category.jinja2
@@ -1,4 +1,6 @@
-{% set name = cat.name %}
+{%import "macros.jinja2" as macros %}
+{% set name = joindir(d=cat.dirname, n=cat.name) %}
+
 <html>
 <meta charset="UTF-8">
 <link rel="stylesheet" type="text/css" href="/css/category.css">
@@ -7,7 +9,7 @@
 <body>
 <div class="cat_wrapper">
     <div class="box cat_url">
-        <a id="siteurl" href="/">redsys.pw</a>/<a id="path", href="{{ name | urlencode }}.html">{{ name }}</a> <!-- PATH TO FILE, IF JS -->
+        <a id="siteurl" href="/">redsys.pw</a><a id="path", href="{{ name | urlencode }}.html">/{{ name }}</a> <!-- PATH TO FILE, IF JS -->
     </div>
     <div class="box blank"></div>
     <div class="box items">
@@ -15,43 +17,16 @@
         {% for c in childcats %}
             <div class="childcat">
                 <div class="box cat_child_title">
-                    <a class="cat_child_url" href="{{ name | urlencode }}/{{ c.name | urlencode }}.html">/{{ c.name }}</a>
+                    <a class="cat_child_url" href="/{{ joindir(d=c.dirname, n=c.name) | urlencode }}.html">/{{ c.name }}</a>
                 </div>
             </div>
         {% endfor %}
         {% for post in childposts %} 
             <div class="post_wrapper">
-                <div class="box title">
-                        <div class="left"><a href="{{ name ~ '/' ~ post.name | urlencode }}.html">{{ post.name }}</a></div>{% if post.year %}
-                        <div class="right">[{{ post.year }}]</div>{% endif %}</div>
-                    <div class="box image"><img src="{{ post.image }}"></div>
-                    <div class="box tags">
-                        <ul style="list-style-type: none;">
-                        {% for other_parent in post.parent_names %}
-                            <li ><a class="parent_url" href="{{ name ~ '/' ~ post.name ~ '/' ~ other_parent | urlencode }}.html"><span class="uparrow">➤</span> /{{ other_parent }}</a></li>
-                        {% endfor %}
-                        {% for child in post.children %}
-                            <li ><a class="child_url" href="{{ name ~ '/' ~ post.name ~ '/' ~ child | urlencode }}.html">/{{ child }}</a></li>
-                        {% endfor %}
-                    </ul>
-                </div>
+                {{ macros::post_header(post=post) }}
             </div>
         {% endfor %}
     </div>
 </div>
 </body>
-<script type="text/javascript">
-function update_path(){
-    let path = window.location.pathname.split('/').slice(1, -1);
-    var sitenode = document.getElementById('siteurl');
-    for (var i = path.length; i > 0; i--){
-        let a = document.createElement('a');
-        a.href = '/' + path.slice(0, i).join('/') + '.html';
-		console.log(i, path.slice(0,i));
-        a.text = decodeURI('/' + path[i-1]);
-        sitenode.parentNode.insertBefore(a, sitenode.nextSibling);
-    }
-}
-update_path();
-</script>
 </html>

--- a/templates/jinja2/macros.jinja2
+++ b/templates/jinja2/macros.jinja2
@@ -1,23 +1,18 @@
-{% macro post_header(post, direct_parent="") -%} 
+{% macro post_header(post) -%} 
     <div class="box title">
-        <div class="left">{% if parent != "" %} <a href="{{ direct_parent ~ '/' ~ post.name | urlencode }}.html">{{ post.name }}</a> {%else%}{{ post.name }}{%endif%}</div>{% if post.year %}
-        <div class="right">[{{ post.year }}]</div>{% endif %}</div>
-    <div class="box image"><img src="{{ post.image }}"></div>
-    <div class="box tags">
-        <ul style="list-style-type: none;">
-            {% for other_parent in post.parent_names %}
-                {% if direct_parent == "" %} 
-                <li ><a class="parent_url" href="{{ '../' ~ other_parent | urlencode }}.html"><span style="transform: rotate(-90deg);display: inline-block;">➤</span>/{{ other_parent }}</a></li>
-                {% else %}
-                {%endif%}
-
+        <div class="left"><a href="/{{ joindir(d=post.dirname, n=post.name) | urlencode }}.html">{{ post.name }}</a></div>
+        {%- if post.year -%}
+        <div class="right">[{{ post.year }}]</div>
+        {%- endif %}
+    </div>
+        <div class="box image"><img src="{{ post.image }}"></div>
+        <div class="box tags">
+            <ul style="list-style-type: none;">
+            {% for parent in post.parent_names %}
+                <li ><a class="parent_url" href="/{{ parent | urlencode }}.html"><span class="uparrow">➤</span> /{{ parent }}</a></li>
             {% endfor %}
             {% for child in post.children %}
-                {% if direct_parent == "" %}
-                <li ><a class="child_url" href="{{ post.name ~ '/' ~  child | urlencode }}.html">/{{ child }}</a></li>
-                {%else%}
-                <li ><a class="child_url" href="{{ direct_parent ~ '/' ~ post.name ~ '/' ~ child | urlencode }}.html">/{{ child }}</a></li>
-                {%endif%}
+                <li ><a class="child_url" href="/{{ child | urlencode }}.html">/{{ child }}</a></li>
             {% endfor %}
         </ul>
     </div>

--- a/templates/jinja2/post.jinja2
+++ b/templates/jinja2/post.jinja2
@@ -1,3 +1,5 @@
+{%import "macros.jinja2" as macros %}
+{% set name = joindir(d=post.dirname, n=post.name) %}
 <html>
 <meta charset="UTF-8">
 <link rel="stylesheet" type="text/css" href="/css/post.css">
@@ -6,23 +8,10 @@
 <body>
 <div class="post_wrapper">
     <div class="box url">
-        <a id="siteurl" href="/">redsys.pw</a>/<a id="path", href="{{ post.name | urlencode }}.html">{{ post.name }}</a> <!-- PATH TO FILE, IF JS -->
+        <a id="siteurl" href="/">redsys.pw</a><a id="path", href="{{ name | urlencode }}.html">/{{ name }}</a> <!-- PATH TO FILE, IF JS -->
     </div>
     <div class="box blank"></div>
-        <div class="box title">
-        <div class="left">{{ post.name }}</div>{% if post.year %}
-        <div class="right">[{{ post.year }}]</div>{% endif %}</div>
-    <div class="box image"><img src="{{ post.image }}"></div>
-    <div class="box tags">
-        <ul style="list-style-type: none;">
-            {% for other_parent in post.parent_names %}
-                <li ><a class="parent_url" href="{{ '../' ~ other_parent | urlencode }}.html"><span style="transform: rotate(-90deg);display: inline-block;">➤</span> /{{ other_parent }}</a></li>
-            {% endfor %}
-            {% for child in post.children %}
-                <li ><a class="child_url" href="{{ post.name ~ '/' ~  child | urlencode }}.html">/{{ child }}</a></li>
-            {%endfor%}
-        </ul>
-    </div>
+    {{ macros::post_header(post=post) }}
     <div class="box body">
         {{ post.body | parsemd | safe }}
     </div>
@@ -34,40 +23,4 @@
     </div>
 </div>
 </body>
-<script type="text/javascript">
-// if we're in a cycle, we'd have to generate an infinite number of symlinks in the current system
-// so instead, if we encounter a node we've already seen, we retreat back up the path to the previous
-// occurrence.
-function update_cyclical_children(classname){
-let parents = window.location.pathname.split('/').slice(1, -1);
-let children = document.getElementsByClassName(classname);
-Array.from(children).forEach(
-	function(child, index) { 
-		let nextPost = child.getAttribute("href").split('/').slice(-1)[0].slice(0,-5);
-		for (var i in parents) {
-			if (parents[i] === nextPost) {
-				console.log(i);
-				let newurl = parents.slice(0, i).join('/') + "/" + nextPost + ".html";
-				children.item(index).href = newurl
-				console.log(newurl);
-				return
-         	}
-        }
-	}) 
-}
-function update_path(){
-    let path = window.location.pathname.split('/').slice(1, -1);
-    var sitenode = document.getElementById('siteurl');
-    for (var i = path.length; i > 0; i--){
-        let a = document.createElement('a');
-        a.href = '/' + path.slice(0, i).join('/') + '.html';
-		console.log(i, path.slice(0,i));
-        a.text = decodeURI('/' + path[i-1]);
-        sitenode.parentNode.insertBefore(a, sitenode.nextSibling);
-    }
-}
-
-update_cyclical_children();
-update_path();
-</script>
 </html>


### PR DESCRIPTION
Encoding the path taken in the URL in a graph is basically nonsense,
if you allow for traversing **up** as well as down the graph. You can
move to a parent-node that is entirely seperate from the path-history
you to took, except that child node joining them.

The only solution is to pick some random path to reach the parent node,
and rewrite the URL to it... which kills the point of having the path recorded.

If we're removing the URL-recording, then there's also no reason to have
the symlink system either. So that's also gone out the window. With the
removal of the symlinks, a large chunk of the post_graph.rs code has
become dead code, and should be removed (but hasn't been yet).

This also means that we can move the output up to the root dir, and get
rid of src/.

Also added support for directories in the output directory, with new
field `dirname` in the post metadata.

So finally, the graph is now encoded by the HTML links, and not in the
filesystem. This also means the JS code is unecessary, and was removed.

:-)

Closes #5 